### PR TITLE
Update lightweight curl client command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you'd like an alternative on Windows that supports functionality similar to `
 Han Boetes and @nickthename have contributed a simple shell-script alternative for those not interested in installing a RubyGem:
 
 ``` bash
-haste() { a=$(cat); curl -X POST -s -d "$a" http://hastebin.com/documents | awk -F '"' '{print "http://hastebin.com/"$4}'; }
+haste() { curl -X POST -s --data-binary @- http://hastebin.com/documents | awk -F '"' '{print "http://hastebin.com/"$4}'; }
 ```
 
 Usage:


### PR DESCRIPTION
The currently suggested lightweight curl client in the README has limited input capability (since the input is passed as a direct argument to curl) and doesn't preserve line breaks. This commit changes the curl command to read data directly from stdin (using `@-`) and preserves line breaks in the data (using `--data-binary`).
